### PR TITLE
Support binary variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearFractional"
 uuid = "31851ddc-f9b7-5097-a470-69ef907d7682"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -13,8 +13,9 @@ julia = "^1.1"
 
 [extras]
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Clp", "Test", "LinearAlgebra"]
+test = ["Clp", "Cbc", "Test", "LinearAlgebra"]

--- a/test/mip.jl
+++ b/test/mip.jl
@@ -15,4 +15,12 @@
     @test termination_status(lfp) === MOI.OPTIMAL
     @test value(x1) ≈ 1.0
     @test value(x2) ≈ 0.0
+
+    @testset "Set the binary big-M" begin
+        lfp = LinearFractionalModel(with_optimizer(Cbc.Optimizer); binary_M = 100.0)
+        @test lfp.options.binary_M == 100.0
+
+        lfp = LinearFractionalModel(with_optimizer(Cbc.Optimizer); binary_M = 10.0)
+        @test lfp.options.binary_M == 10.0
+    end
 end

--- a/test/mip.jl
+++ b/test/mip.jl
@@ -1,0 +1,18 @@
+@testset "Binary Variables" begin
+    lfp = LinearFractionalModel(with_optimizer(Cbc.Optimizer))
+
+    x1 = @variable(lfp, lower_bound=0, base_name="x1", binary=true)
+    x2 = @variable(lfp, lower_bound=0, binary=true, base_name="x2")
+    @constraint(lfp, -x1 + x2 <= 4)
+    @constraint(lfp, 2x1 + x2 <= 14)
+
+    LinearFractional.set_objective(lfp, MOI.MIN_SENSE,
+              @expression(lfp, -2x1 + x2 + 2),
+              @expression(lfp, x1 + -x2 + 4))
+
+    optimize!(lfp)
+
+    @test termination_status(lfp) === MOI.OPTIMAL
+    @test value(x1) ≈ 1.0
+    @test value(x2) ≈ 0.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using Test
 using LinearFractional
 using LinearAlgebra
-using Clp
+using Clp, Cbc
 using JuMP
 
-mytests = ["simpletest.jl", "arrayvars.jl"]
+mytests = ["simpletest.jl", "arrayvars.jl", "mip.jl"]
 
 for mytest in mytests
     include(mytest)


### PR DESCRIPTION
In the current version, binary variables silently do the wrong thing.  They enforce binaryness of the transformed variable instead of the untransformed variables.  Transformed variables should be in the set {0, t}, whereas untransformed binaries are in {0, 1}.