### PR TITLE
relax type constraints in LinearFractionalModel constructor

### DIFF
--- a/src/LinearFractional.jl
+++ b/src/LinearFractional.jl
@@ -97,7 +97,7 @@ mutable struct LinearFractionalModel <: AbstractModel
     end
 end
 
-function LinearFractionalModel(optimizer::Union{Type{<:MOI.AbstractOptimizer}, MOI.OptimizerWithAttributes};
+function LinearFractionalModel(optimizer;
                bridge_constraints::Bool=true, kwargs...)
     model = LinearFractionalModel(; kwargs...)
     JuMP.set_optimizer(model.model, optimizer,


### PR DESCRIPTION
Thanks for this really cool and useful package! 

This is a very minor modification that allows the following:

```julia
using MosekTools
lfp = LinearFractionalModel(Mosek.Optimizer)
```
(Without this PR, the above code throws an error.)