### PR TITLE
Bugfix for JuMP 1.13

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearFractional"
 uuid = "31851ddc-f9b7-5097-a470-69ef907d7682"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-JuMP = "^1"
+JuMP = "^1.13"
 MacroTools = "^0.5"
 MathOptInterface = "^1"
 julia = "^1.6"

--- a/src/LinearFractional.jl
+++ b/src/LinearFractional.jl
@@ -160,6 +160,7 @@ Base.copy(v::LinearFractionalVariableRef, new_model::LinearFractionalModel) = Li
 Base.:(==)(v::LinearFractionalVariableRef, w::LinearFractionalVariableRef) = v.model === w.model && (v.vref == w.vref)
 Base.broadcastable(v::LinearFractionalVariableRef) = Ref(v)
 JuMP.isequal_canonical(v::LinearFractionalVariableRef, w::LinearFractionalVariableRef) = v == w
+JuMP.variable_ref_type(::Union{LinearFractionalModel, Type{LinearFractionalModel}}) = LinearFractionalVariableRef
 function JuMP.add_variable(m::LinearFractionalModel, v::JuMP.AbstractVariable, name::String="")
 
     inner_vref = JuMP.add_variable(m.model, v, name)

--- a/test/simpletest.jl
+++ b/test/simpletest.jl
@@ -38,3 +38,10 @@ end
     @test value(x1) ≈ 7.0
     @test value(x2) ≈ 0.0
 end
+
+@testset "Optimizer With Fixed Constraints" begin
+    lfp = LinearFractionalModel(MOI.OptimizerWithAttributes(Clp.Optimizer, "LogLevel" => 4))
+    @constraint(lfp, fixed_c, 1 + 1 == 2)
+
+    @test lfp[:fixed_c] === fixed_c
+end


### PR DESCRIPTION
JuMP v1.13 requires supporting the `JuMP.variable_ref_type` method. This is required to support constraints of the type,

```
x1 = 1.0
x2 = 1.0
y = 2.0
@constraint(model, x1 + x2 == y)
```

This PR exports this method for the `LinearFractionalModel` and adds a test to ensure constraints of the type above can be added to the model.