### PR TITLE
new is_valid method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-JuMP = "=1.22.1"
+JuMP = "1.13 - 1.22.1"
 MacroTools = "^0.5"
 MathOptInterface = "^1"
 julia = "^1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearFractional"
 uuid = "31851ddc-f9b7-5097-a470-69ef907d7682"
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -8,7 +8,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-JuMP = "^1.13"
+JuMP = "=1.22.1"
 MacroTools = "^0.5"
 MathOptInterface = "^1"
 julia = "^1.6"

--- a/src/LinearFractional.jl
+++ b/src/LinearFractional.jl
@@ -189,7 +189,7 @@ end
 function JuMP.delete(model::LinearFractionalModel, vref::LinearFractionalVariableRef)
     JuMP.delete(model.model, vref.vref)
 end
-function JuMP.is_valid(model::LinearFractionalModel, vref::LinearFractionalVariableRef)
+function JuMP.is_valid(model::Union{LinearFractionalModel, JuMP.Model}, vref::LinearFractionalVariableRef)
     return (model === vref.model &&
             is_valid(model.model, vref.vref))
 end

--- a/src/LinearFractional.jl
+++ b/src/LinearFractional.jl
@@ -189,7 +189,7 @@ end
 function JuMP.delete(model::LinearFractionalModel, vref::LinearFractionalVariableRef)
     JuMP.delete(model.model, vref.vref)
 end
-function JuMP.is_valid(model::Union{LinearFractionalModel, JuMP.Model}, vref::LinearFractionalVariableRef)
+function JuMP.is_valid(model::LinearFractionalModel, vref::LinearFractionalVariableRef)
     return (model === vref.model &&
             is_valid(model.model, vref.vref))
 end


### PR DESCRIPTION

1. Keep JuMP version to less than 1.22.2. There seems to be a breaking change in 1.22.2 that causes the @variable macro to return an InvalidVariableRef for some LInearFractional models. This is the JuMP update that I believe causes this behavior. https://github.com/jump-dev/JuMP.jl/commit/56b186fc18d854be33a7f558bc2ba1918dd7c86d