### PR TITLE
Add support for (rotated) second order cones

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,9 @@ julia = "^1.6"
 [extras]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
+ECOS = "e2685f51-7e38-5353-a97d-a921fd2c8199"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Clp", "Cbc", "Test", "LinearAlgebra"]
+test = ["Clp", "Cbc", "ECOS", "Test", "LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearFractional"
 uuid = "31851ddc-f9b7-5097-a470-69ef907d7682"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/LinearFractional.jl
+++ b/src/LinearFractional.jl
@@ -255,26 +255,6 @@ function transform_constraint(model::LinearFractionalModel, constraint_ref::Cons
     JuMP.set_normalized_coefficient(constraint_ref, model.t, -α)
 end
 
-#function transform_constraint(
-#    model::LinearFractionalModel,
-#    constraint_ref::ConstraintRef{<:AbstractModel, MOI.ConstraintIndex{F,S}}
-#) where {F<:MOI.VectorAffineFunction{Float64}, S<:Union{MOI.SecondOrderCone,  MOI.RotatedSecondOrderCone}}
-    
-#    con = constraint_object(constraint_ref)
-#    func = jump_function(con)
-
-#    constants = [expr.constant for expr in func]
-    
-#    MOI.modify(backend(model.model), index(constraint_ref), 
-#              MOI.VectorConstantChange(zeros(length(constants))))
-              
-#    coefficients = [(i, α) for (i, α) in enumerate(constants) if !iszero(α)]
-#    if !isempty(coefficients)
-#        MOI.modify(backend(model.model), index(constraint_ref),
-#                  MOI.MultirowChange(index(model.t), coefficients))
-#    end
-
-#end
 
 function JuMP.add_constraint(
     model::LinearFractionalModel, 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,10 @@ using Test
 using LinearFractional
 using LinearAlgebra
 using Clp, Cbc
+using ECOS
 using JuMP
 
-mytests = ["simpletest.jl", "arrayvars.jl", "mip.jl"]
+mytests = ["simpletest.jl", "arrayvars.jl", "mip.jl", "socp.jl"]
 
 for mytest in mytests
     include(mytest)

--- a/test/socp.jl
+++ b/test/socp.jl
@@ -1,0 +1,64 @@
+@testset "Basic SOCP with linear fractional objective" begin
+    model = LinearFractionalModel(ECOS.Optimizer)
+    
+    @variable(model, y₁ >= 1)
+    @variable(model, y₂)
+    @constraint(model, y₁ <= 2)
+    @constraint(model, [1y₁; y₂] in SecondOrderCone())
+    
+    set_objective(model, MOI.MIN_SENSE, y₁ + 2y₂, y₁ + 1)
+    optimize!(model)
+    
+    @test termination_status(model) === MOI.OPTIMAL
+
+    # worked out manually
+    @test isapprox(value(y₁), 2.0, rtol=1e-4)
+    @test isapprox(value(y₂), -2.0, rtol=1e-4)
+    @test isapprox(objective_value(model), -2/3, rtol=1e-4)
+end
+
+
+@testset "Multiple cone constraints with optimality verification" begin
+    # Solve the original problem
+    model = LinearFractionalModel(ECOS.Optimizer)
+    
+    @variable(model, x[1:2] >= 0.1)
+    
+    set_objective(model, MOI.MIN_SENSE, 
+        2x[1] + x[2] + 1,   # numerator
+        x[1] + 2x[2] + 2    # denominator
+    )
+
+    @constraint(model, [1.0; x[1]; x[2]] in SecondOrderCone())
+    @constraint(model, [x[1] + x[2]; x[1]; x[2]] in RotatedSecondOrderCone())
+
+    optimize!(model)
+    
+    @test termination_status(model) === MOI.OPTIMAL
+    opt_x = value.(x)
+    opt_val = objective_value(model)
+    
+    # Test cone constraints satisfaction
+    @test norm([opt_x[1]; opt_x[2]]) <= 1.0 + 1e-4
+    @test 2 * (opt_x[1] + opt_x[2]) * opt_x[1] >= opt_x[2]^2 - 1e-4
+    @test all(opt_x .>= 0.1 - 1e-4)
+
+    # Verify optimality by checking feasibility of perturbed problems
+
+    function solve_feasibility_problem(γ)
+        m = Model(ECOS.Optimizer)
+        
+        @variable(m, x[1:2] >= 0.1)
+        @constraint(m, [1.0; x[1]; x[2]] in SecondOrderCone())
+        @constraint(m, [x[1] + x[2]; x[1]; x[2]] in RotatedSecondOrderCone())
+        
+        @constraint(m, 2x[1] + x[2] + 1 <= γ * (x[1] + 2x[2] + 2))
+        
+        optimize!(m)
+        return termination_status(m)
+    end
+
+    # Test with perturbations around optimal value
+    @test solve_feasibility_problem(opt_val + 1e-4) == MOI.OPTIMAL  # Should be feasible
+    @test solve_feasibility_problem(opt_val - 1e-4) == MOI.INFEASIBLE  # Should be infeasible
+end


### PR DESCRIPTION
As mentioned in the title, this PR adds support for second order cone and rotated second order cone constraints in convex programs with linear fractional objective. 

This implementation required working with the internals of MOI/JuMP to handle the cone transformations during problem reformulation. While it works in my testing, I do not understand the MOI/JuMP internals well enough to be certain this is the best/correct way to implement it. The same technique should work in principle with other conic constraints, but I have only implemented these two cones as these were my immediate needs.

Also added ECOS to the tests to ensure the functionality works with an open-source SOCP solver.
